### PR TITLE
Audio fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ boto3>=1.26.0
 botocore>=1.29.0
 # Environment management
 python-dotenv>=0.19.0
+streamlit_autorefresh

--- a/src/app.py
+++ b/src/app.py
@@ -276,7 +276,7 @@ else:
                             
                             if freq_out_of_bounds:
                                 st.error("⚠️ Frequency out of bounds!")
-                            if delay_too_large:
+                            elif delay_too_large:
                                 st.error("⚠️ Delay too large!")
                             else:
                                 st.success("✅ Device operating normally")
@@ -306,23 +306,5 @@ else:
         
         if needs_alarm:
             audio_path = os.path.join(artifacts_dir, 'warning.wav')
-            # st.html(
-            #         f'<audio autoplay loop><source src="{audio_path}" type="audio/wav"></audio>', 
-            #         # height=0
-            #         )
             st.audio(audio_path, autoplay=True, loop=True)
-            # if len(audio_elements) == 0:  # Only play audio once
-            #     this_audio = st.audio(os.path.join(artifacts_dir, 'warning.wav'),
-            #                         autoplay=True, loop=True)
-            #     audio_elements.append(this_audio)
-        # else:
-        #     if len(audio_elements) > 0:
-        #         audio_elements[0].empty()
-        #         audio_elements = []
-        # 
-        # Clear alarm conditions for next refresh
         st.session_state.alarm_conditions = []
-    
-    # Auto-refresh
-    # time.sleep(refresh_interval)
-    # st.rerun()


### PR DESCRIPTION
With `st.rerun`, `st.audio` gives duplicate widget error and asks to instantiate it with different keys
Found no good way to provide `st.audio` with a key (unlike other widgets, it doesn't take a `key` argument).
Instead of using `st.rerun`, `st_autorefresh` to refresh page on frontend.
Also moved `st.audio` outside of columns. All alarm conditions are evaluated and alarm is raised if conditions are met
 